### PR TITLE
Remove "raw confidence" value from website

### DIFF
--- a/api/run_model.py
+++ b/api/run_model.py
@@ -254,8 +254,10 @@ def predict():
         features_df = process_data(combined_df, curr_time)
         
         # Predict, get response and confidence of True (PMI)
-        prediction = model.predict(features_df)[0]
-        confidence = model.predict_proba(features_df)[0][1]
+        # Convert DataFrame to numpy array to drop feature names
+        features_array = features_df.values
+        prediction = model.predict(features_array)[0]
+        confidence = model.predict_proba(features_array)[0][1]
         
         # Save results
         results.append({

--- a/website/static/js/scripts.js
+++ b/website/static/js/scripts.js
@@ -50,14 +50,11 @@ document.addEventListener('DOMContentLoaded', function () {
             var predictionHeader = document.createElement('th');
             predictionHeader.textContent = 'Prediction';
             var confidenceHeader = document.createElement('th');
-            confidenceHeader.textContent = 'Confidence (Adjusted)';
-            var rawConfidenceHeader = document.createElement('th');
-            rawConfidenceHeader.textContent = 'Raw Confidence';
+            confidenceHeader.textContent = 'Confidence';
             
             headerRow.appendChild(timestampHeader);
             headerRow.appendChild(predictionHeader);
             headerRow.appendChild(confidenceHeader);
-            headerRow.appendChild(rawConfidenceHeader);
             table.appendChild(headerRow);
 
             // Add data rows
@@ -91,14 +88,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 confidenceCell.textContent = confidenceValue;
                 confidenceCell.appendChild(confidenceBar);
                 
-                var rawConfidenceCell = document.createElement('td');
-                var rawConfidenceValue = (result.raw_confidence * 100).toFixed(2) + '%';
-                rawConfidenceCell.textContent = rawConfidenceValue;
-                
                 row.appendChild(timestampCell);
                 row.appendChild(predictionCell);
                 row.appendChild(confidenceCell);
-                row.appendChild(rawConfidenceCell);
                 table.appendChild(row);
             });
 
@@ -113,11 +105,10 @@ document.addEventListener('DOMContentLoaded', function () {
             chartContainer.appendChild(canvas);
             resultsDiv.appendChild(chartContainer);
             
-            // Create chart with both confidence metrics
+            // Create chart
             var ctx = canvas.getContext('2d');
             var timeLabels = data.map(item => item.timestamp);
             var confidenceData = data.map(item => item.confidence);
-            var rawConfidenceData = data.map(item => item.raw_confidence);
             var colors = data.map(item => item.prediction ? 
                 `rgba(0, 128, 0, ${item.confidence})` : 
                 `rgba(255, 0, 0, ${item.confidence})`);
@@ -126,25 +117,14 @@ document.addEventListener('DOMContentLoaded', function () {
                 type: 'line',
                 data: {
                     labels: timeLabels,
-                    datasets: [
-                        {
-                            label: 'Adjusted Confidence',
-                            data: confidenceData,
-                            borderColor: 'rgba(75, 192, 192, 1)',
-                            backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                            borderWidth: 2,
-                            fill: false
-                        },
-                        {
-                            label: 'Raw Confidence',
-                            data: rawConfidenceData,
-                            borderColor: 'rgba(192, 75, 75, 1)',
-                            backgroundColor: 'rgba(192, 75, 75, 0.2)',
-                            borderWidth: 2,
-                            borderDash: [5, 5],
-                            fill: false
-                        }
-                    ]
+                    datasets: [{
+                        label: 'Confidence Over Time',
+                        data: confidenceData,
+                        backgroundColor: colors,
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        borderWidth: 1,
+                        fill: false
+                    }]
                 },
                 options: {
                     responsive: true,


### PR DESCRIPTION
# Overview

**Type of Change:** Refactoring

**Summary:** Removed the "Raw Confidence" value shown on our website as it is not yet applicable and just makes the UI more confusing. 

## UI/UX Implementation

Removed "Raw Confidence" column from the PMI table.

## Model Updates

No changes made.

### Data Models

No changes made.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

No changes made.
